### PR TITLE
Add `engines` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "A cloud service that stores and serves data about blockchain activity",
   "version": "0.0.1",
   "private": true,
+  "engines": {
+    "node": "^12"
+  },
   "author": "Valora Inc",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Once we enable dependabot, this will make it a little more obvious when we try
to bump dependencies that require a more modern Node.js version.