### PR TITLE
Return txs with fees paid in cREAL

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "prettier": "@valora/prettier-config",
   "dependencies": {
-    "@celo/contractkit": "1.3.3",
-    "@celo/utils": "1.3.3",
+    "@celo/contractkit": "1.5.1",
+    "@celo/utils": "1.5.1",
     "@google-cloud/logging-bunyan": "~3.1.1",
     "@valora/exchanges": "^2.0.2",
     "@valora/secrets-loader": "^1.0.0",

--- a/src/blockscout.ts
+++ b/src/blockscout.ts
@@ -312,6 +312,9 @@ export class BlockscoutAPI extends RESTDataSource {
       if (!contractAddresses.ExchangeEUR) {
         throw new Error('Cannot find exchange EUR address')
       }
+      if (!contractAddresses.ExchangeBRL) {
+        throw new Error('Cannot find exchange BRL address')
+      }
       if (!contractAddresses.Reserve) {
         throw new Error('Cannot find reserve address')
       }

--- a/src/events/ExchangeContractCall.ts
+++ b/src/events/ExchangeContractCall.ts
@@ -7,7 +7,8 @@ export class ExchangeContractCall extends TransactionType {
     return (
       transaction.transfers.length === 0 &&
       (transaction.input.hasContractCallTo(Contracts.Exchange) ||
-        transaction.input.hasContractCallTo(Contracts.ExchangeEUR))
+        transaction.input.hasContractCallTo(Contracts.ExchangeEUR) ||
+        transaction.input.hasContractCallTo(Contracts.ExchangeBRL))
     )
   }
 

--- a/src/events/ExchangeTokenToCelo.ts
+++ b/src/events/ExchangeTokenToCelo.ts
@@ -16,7 +16,8 @@ export class ExchangeTokenToCelo extends TransactionType {
       transaction.transfers.length === 3 &&
       containsTransferFrom(transaction.transfers, Contracts.Reserve) &&
       (containsTransferTo(transaction.transfers, Contracts.Exchange) ||
-        containsTransferTo(transaction.transfers, Contracts.ExchangeEUR)) &&
+        containsTransferTo(transaction.transfers, Contracts.ExchangeEUR) ||
+        containsTransferTo(transaction.transfers, Contracts.ExchangeBRL)) &&
       containsBurnedTokenTransfer(transaction.transfers)
     )
   }
@@ -24,7 +25,8 @@ export class ExchangeTokenToCelo extends TransactionType {
   async getEvent(transaction: Transaction) {
     const inTransfer =
       getTransferTo(transaction.transfers, Contracts.Exchange) ??
-      getTransferTo(transaction.transfers, Contracts.ExchangeEUR)
+      getTransferTo(transaction.transfers, Contracts.ExchangeEUR) ??
+      getTransferTo(transaction.transfers, Contracts.ExchangeBRL)
     const outTransfer = getTransferFrom(
       transaction.transfers,
       Contracts.Reserve,

--- a/src/helpers/FirebaseListener.ts
+++ b/src/helpers/FirebaseListener.ts
@@ -4,7 +4,10 @@ import { logger } from '../logger'
 
 const ON_VALUE_CHANGED = 'value'
 
-export function listenFromFirebase<T>(path: string, callback: (value: T) => void): void {
+export function listenFromFirebase<T>(
+  path: string,
+  callback: (value: T) => void,
+): void {
   const onError = (error: Error) => {
     logger.error({
       type: 'ERROR_LISTENING_TO_FIREBASE',

--- a/src/helpers/FirebaseListener.ts
+++ b/src/helpers/FirebaseListener.ts
@@ -1,0 +1,21 @@
+import { DataSnapshot } from '@firebase/database-types'
+import { database } from '../firebase'
+import { logger } from '../logger'
+
+const ON_VALUE_CHANGED = 'value'
+
+export function listenFromFirebase<T>(path: string, callback: (value: T) => void): void {
+  const onError = (error: Error) => {
+    logger.error({
+      type: 'ERROR_LISTENING_TO_FIREBASE',
+      error: error.message,
+    })
+  }
+
+  const onValue = (snapshot: DataSnapshot) => {
+    const value = snapshot.val()
+    callback(value)
+  }
+
+  database.ref(path).on(ON_VALUE_CHANGED, onValue, onError)
+}

--- a/src/helpers/KnownAddressesCache.ts
+++ b/src/helpers/KnownAddressesCache.ts
@@ -1,36 +1,25 @@
-import { DataSnapshot } from '@firebase/database-types'
-import { database } from '../firebase'
 import { logger } from '../logger'
+import { listenFromFirebase } from './FirebaseListener'
 
 const ROOT_KEY = 'addressesExtraInfo'
-
-const ON_VALUE_CHANGED = 'value'
 
 export interface DisplayInfo {
   name?: string
   imageUrl?: string
 }
 
+interface KnownAddresses {
+  [address: string]: DisplayInfo | undefined
+}
+
 class KnownAddressesCache {
-  private knownAddresses: {
-    [address: string]: DisplayInfo | undefined
-  } = {}
+  private knownAddresses: KnownAddresses = {}
 
   startListening(): void {
-    const onError = (error: Error) => {
-      logger.error({
-        type: 'ERROR_FETCHING_KNOWN_ADDRESSES',
-        error: error.message,
-      })
-    }
-
-    const onValue = (snapshot: DataSnapshot) => {
-      const value = snapshot.val()
+    listenFromFirebase(ROOT_KEY, (value: KnownAddresses) => {
       logger.info({ type: 'FETCHED_KNOWN_ADDRESSES' })
       this.knownAddresses = value ?? this.knownAddresses
-    }
-
-    database.ref(ROOT_KEY).on(ON_VALUE_CHANGED, onValue, onError)
+    })
   }
 
   getDisplayInfoFor(address: string): DisplayInfo {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,19 @@
+import {
+  configs as exchangesConfigs, createNewManager
+} from '@valora/exchanges'
+import { loadSecret } from '@valora/secrets-loader'
 import express from 'express'
 import promBundle from 'express-prom-bundle'
+import yargs from 'yargs'
 import { initApolloServer } from './apolloServer'
 import CurrencyConversionAPI from './currencyConversion/CurrencyConversionAPI'
 import ExchangeRateAPI from './currencyConversion/ExchangeRateAPI'
-import knownAddressesCache from './helpers/KnownAddressesCache'
-import { logger } from './logger'
-import { loadSecret } from '@valora/secrets-loader'
 import { initDatabase } from './database/db'
-import { updatePrices } from './prices/PricesUpdater'
-import yargs from 'yargs'
-import {
-  createNewManager,
-  configs as exchangesConfigs,
-} from '@valora/exchanges'
+import knownAddressesCache from './helpers/KnownAddressesCache'
+import tokenInfoCache from './helpers/TokenInfoCache'
+import { logger } from './logger'
 import PricesService from './prices/PricesService'
+import { updatePrices } from './prices/PricesUpdater'
 
 const metricsMiddleware = promBundle({ includeMethod: true, includePath: true })
 
@@ -126,6 +126,7 @@ async function main() {
   })
 
   knownAddressesCache.startListening()
+  tokenInfoCache.startListening()
 
   const exchangeRateAPI = new ExchangeRateAPI({
     exchangeRatesAPIAccessKey: args['exchange-rates-api-access-key'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import {
-  configs as exchangesConfigs, createNewManager
+  configs as exchangesConfigs,
+  createNewManager,
 } from '@valora/exchanges'
 import { loadSecret } from '@valora/secrets-loader'
 import express from 'express'

--- a/src/legacyEvents/LegacyExchangeContractCall.ts
+++ b/src/legacyEvents/LegacyExchangeContractCall.ts
@@ -7,7 +7,8 @@ export class LegacyExchangeContractCall extends LegacyTransactionType {
     return (
       transaction.transfers.isEmpty() &&
       (transaction.input.hasContractCallTo(Contracts.Exchange) ||
-        transaction.input.hasContractCallTo(Contracts.ExchangeEUR))
+        transaction.input.hasContractCallTo(Contracts.ExchangeEUR) ||
+        transaction.input.hasContractCallTo(Contracts.ExchangeBRL))
     )
   }
 

--- a/src/legacyEvents/LegacyExchangeTokenToCelo.ts
+++ b/src/legacyEvents/LegacyExchangeTokenToCelo.ts
@@ -9,7 +9,8 @@ export class LegacyExchangeTokenToCelo extends LegacyTransactionType {
       transaction.transfers.length === 3 &&
       transaction.transfers.containsTransferFrom(Contracts.Reserve) &&
       (transaction.transfers.containsTransferTo(Contracts.Exchange) ||
-        transaction.transfers.containsTransferTo(Contracts.ExchangeEUR)) &&
+        transaction.transfers.containsTransferTo(Contracts.ExchangeEUR) ||
+        transaction.transfers.containsTransferTo(Contracts.ExchangeBRL)) &&
       transaction.transfers.containsBurnedTokenTransfer()
     )
   }
@@ -17,7 +18,8 @@ export class LegacyExchangeTokenToCelo extends LegacyTransactionType {
   getEvent(transaction: LegacyTransaction) {
     const inTransfer =
       transaction.transfers.getTransferTo(Contracts.Exchange) ??
-      transaction.transfers.getTransferTo(Contracts.ExchangeEUR)
+      transaction.transfers.getTransferTo(Contracts.ExchangeEUR) ??
+      transaction.transfers.getTransferTo(Contracts.ExchangeBRL)
     const outTransfer = transaction.transfers.getTransferFrom(Contracts.Reserve)
 
     if (!inTransfer) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,7 @@ export enum Contracts {
   Escrow = 'Escrow',
   Exchange = 'Exchange',
   ExchangeEUR = 'ExchangeEUR',
+  ExchangeBRL = 'ExchangeBRL',
   Governance = 'Governance',
   Reserve = 'Reserve',
   GoldToken = 'GoldToken',
@@ -48,6 +49,7 @@ export interface ContractAddresses {
   [Contracts.Escrow]: string
   [Contracts.Exchange]: string
   [Contracts.ExchangeEUR]: string
+  [Contracts.ExchangeBRL]: string
   [Contracts.Governance]: string
   [Contracts.Reserve]: string
   [Contracts.GoldToken]: string
@@ -84,6 +86,9 @@ export async function getContractAddresses(): Promise<ContractAddresses> {
       ).toLowerCase(),
       ExchangeEUR: (
         await kit.registry.addressFor(CeloContract.ExchangeEUR)
+      ).toLowerCase(),
+      ExchangeBRL: (
+        await kit.registry.addressFor(CeloContract.ExchangeBRL)
       ).toLowerCase(),
       Governance: (
         await kit.registry.addressFor(CeloContract.Governance)

--- a/test/InputDecoderLegacy.test.ts
+++ b/test/InputDecoderLegacy.test.ts
@@ -33,6 +33,7 @@ const contractAddresses = {
   Escrow: '0x0000000000000000000000000000000000a77327',
   Exchange: '0xf1235cb0d3703e7cc2473fb4e214fbc7a9ff77cc',
   ExchangeEUR: '0xd1235cb0d3703e7cc2473fb4e214fbc7a9ff77cc',
+  ExchangeBRL: '0x4a3acb12178b40d8ca2b719cba6bcae0e8e31f4c',
   Governance: '0xa12a699c641cc875a7ca57495861c79c33d293b4',
   Reserve: '0x6a61e1e693c765cbab7e02a500665f2e13ee46df',
   GoldToken: '0xf194afdf50b03e69bd7d057c1aa9e10c9954e4c9',

--- a/test/blockscout.test.ts
+++ b/test/blockscout.test.ts
@@ -36,6 +36,7 @@ jest.mock('../src/utils.ts', () => {
     Escrow: '0x0000000000000000000000000000000000a77327',
     Exchange: '0xf1235cb0d3703e7cc2473fb4e214fbc7a9ff77cc',
     ExchangeEUR: '0xd1235cb0d3703e7cc2473fb4e214fbc7a9ff77cc',
+    ExchangeBRL: '0x4a3acb12178b40d8ca2b719cba6bcae0e8e31f4c',
     Governance: '0xa12a699c641cc875a7ca57495861c79c33d293b4',
     Reserve: '0x6a61e1e693c765cbab7e02a500665f2e13ee46df',
   })

--- a/test/blockscoutV2.test.ts
+++ b/test/blockscoutV2.test.ts
@@ -39,6 +39,7 @@ jest.mock('../src/utils.ts', () => {
     Escrow: '0x0000000000000000000000000000000000a77327',
     Exchange: '0xf1235cb0d3703e7cc2473fb4e214fbc7a9ff77cc',
     ExchangeEUR: '0xd1235cb0d3703e7cc2473fb4e214fbc7a9ff77cc',
+    ExchangeBRL: '0x4a3acb12178b40d8ca2b719cba6bcae0e8e31f4c',
     Governance: '0xa12a699c641cc875a7ca57495861c79c33d293b4',
     Reserve: '0x6a61e1e693c765cbab7e02a500665f2e13ee46df',
   })
@@ -75,6 +76,16 @@ jest.mock('../src/helpers/TokenInfoCache.ts', () => ({
       default:
         return 8
     }
+  },
+  tokenInfoBySymbol: (symbol: string) => {
+    return {
+      cUSD: {
+        address: TEST_DOLLAR_ADDRESS.toLowerCase(),
+      },
+      CELO: {
+        address: TEST_GOLD_ADDRESS.toLowerCase(),
+      },
+    }[symbol]
   },
 }))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -509,10 +509,10 @@
   resolved "https://registry.yarnpkg.com/@celo/base/-/base-1.2.2-beta.tgz#c869adb46375cea96016eea5ae102ff964686e8f"
   integrity sha512-dOwss0fzbpZfSPDbQCcuaTDDLD8iqDOc3TXxRMX6uQ17ykSl9s71EKqcYc4eJgD6vP//sDno/pUbSlnqNiNOIA==
 
-"@celo/base@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@celo/base/-/base-1.3.3.tgz#a74ef1b9a63afd831d5f3ec6399bb98cc2fc733a"
-  integrity sha512-FA7C212AMCRVbWCBFNmmh0AKEStztwxkmMNYGLOSpBNu6QIMvTw/ZZKMqJeXJ0KcZvH0/xK9K3vjVEq2J9Z1HQ==
+"@celo/base@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@celo/base/-/base-1.5.1.tgz#53e16cd36c51f9eaeec0321f6752de6385f2a131"
+  integrity sha512-76MAosahwCDjkBsqfgnKT2CbyjV6TdzIztHJvAuJ+VrKeaIFe/IMoPwIxPy95xDJmHhD0zqPWMixGeyVGAwYQw==
 
 "@celo/connect@1.2.2-beta":
   version "1.2.2-beta"
@@ -526,12 +526,12 @@
     debug "^4.1.1"
     utf8 "3.0.0"
 
-"@celo/connect@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@celo/connect/-/connect-1.3.3.tgz#b9f9b4a634f454c1e72bda751f1bb3108f727ece"
-  integrity sha512-owgLDd3S4vYWR+yjYqx5OXGm9b0YIsOOpgCahyzlQLLEi/XgDhdk9EVdVIFeKv2bgmrZtPE80FqN+9iqNLi+hw==
+"@celo/connect@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@celo/connect/-/connect-1.5.1.tgz#c06631134150c5d0cbf9676a7a45f620e49a5e89"
+  integrity sha512-UjZIu1GRvnsUrGfTUDqxyrt8qyDpj4cuxQ/WVETss8l+x98zV5/7edKOA0QRWEKFhh3F1mCi0N08hEpp+q7QaA==
   dependencies:
-    "@celo/utils" "1.3.3"
+    "@celo/utils" "1.5.1"
     "@types/debug" "^4.1.5"
     "@types/utf8" "^2.1.6"
     bignumber.js "^9.0.0"
@@ -556,15 +556,15 @@
     moment "^2.29.0"
     web3 "1.3.5"
 
-"@celo/contractkit@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@celo/contractkit/-/contractkit-1.3.3.tgz#89d573dd5c354a5b66434e2d77d5ccf77962c3be"
-  integrity sha512-8SIrgwkLddG35gyktLwjyyPJLYeDYTarFt70T/kvn852enEjjickRy7q5BvXzO8sVajuS1f6YgWMO6wk6Emh2Q==
+"@celo/contractkit@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@celo/contractkit/-/contractkit-1.5.1.tgz#723c3516bf08d0598f32dc45a17a99a576c90fa3"
+  integrity sha512-hUgH0yTbI1JUn9ytCWW/0QLfAruF3YL5xfcSmzXItklQ2GKGsTSfGlY7XTUY97xq/WYO2InXw+Vuhop6CcFOiw==
   dependencies:
-    "@celo/base" "1.3.3"
-    "@celo/connect" "1.3.3"
-    "@celo/utils" "1.3.3"
-    "@celo/wallet-local" "1.3.3"
+    "@celo/base" "1.5.1"
+    "@celo/connect" "1.5.1"
+    "@celo/utils" "1.5.1"
+    "@celo/wallet-local" "1.5.1"
     "@types/debug" "^4.1.5"
     bignumber.js "^9.0.0"
     cross-fetch "^3.0.6"
@@ -608,12 +608,12 @@
     web3-eth-abi "1.3.5"
     web3-utils "1.3.5"
 
-"@celo/utils@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@celo/utils/-/utils-1.3.3.tgz#f39f3d22f3c6277ff87ec4eb14074885b81cfea8"
-  integrity sha512-O7AqQIO7+uIb8bSreb75gXyxSY4lt9oKxYP5KYaTOgjcTiH0OqSkxn87mFuuAn0FWAPVUp3CNP0ZINWTHXpGVg==
+"@celo/utils@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@celo/utils/-/utils-1.5.1.tgz#cd5b0309750a25683d9b07c14e643aee2c6a3670"
+  integrity sha512-3ZqZ/YSvzcESd72+8oNOvIM5HieJt3zusRCBPIl97qnqlnCIIq22gxcvpKL1afac0q79t24jkbdl5wsAkD/ROA==
   dependencies:
-    "@celo/base" "1.3.3"
+    "@celo/base" "1.5.1"
     "@types/country-data" "^0.0.0"
     "@types/elliptic" "^6.4.9"
     "@types/ethereumjs-util" "^5.2.0"
@@ -656,14 +656,14 @@
     eth-lib "^0.2.8"
     ethereumjs-util "^5.2.0"
 
-"@celo/wallet-base@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@celo/wallet-base/-/wallet-base-1.3.3.tgz#31397c6a84ff827fb131d738357c4db489b1f790"
-  integrity sha512-huP36Djm86CCj7LvVcxVCIWDvlCRAMzTOiQrmMchfDPy+IOk7eh7SUaPMpxbZb/UY0RQjnjLAF/1XT1h8IJVYg==
+"@celo/wallet-base@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@celo/wallet-base/-/wallet-base-1.5.1.tgz#6f4bf2c487a9e813c267e0c9e12d93886daa0884"
+  integrity sha512-78playqXi/JEwoyLPyPGjaUnPy/PNNjfqSHRD9IF4uTNxTpaUJJXNWKQSoRF2tFwuLdQxC96hrf63Qzepo5Edg==
   dependencies:
-    "@celo/base" "1.3.3"
-    "@celo/connect" "1.3.3"
-    "@celo/utils" "1.3.3"
+    "@celo/base" "1.5.1"
+    "@celo/connect" "1.5.1"
+    "@celo/utils" "1.5.1"
     "@types/debug" "^4.1.5"
     "@types/ethereumjs-util" "^5.2.0"
     bignumber.js "^9.0.0"
@@ -683,14 +683,14 @@
     eth-lib "^0.2.8"
     ethereumjs-util "^5.2.0"
 
-"@celo/wallet-local@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@celo/wallet-local/-/wallet-local-1.3.3.tgz#5dffbe8a6270aedfb3da5584a1ab1522bac876f7"
-  integrity sha512-QOkVl0Onei31+DKN123GuebtrWyGBzvma/iYgG15UlLavNuiXqjUQ2eemP/Zn5vigUPmnOOxT1wwuNr5tja4jA==
+"@celo/wallet-local@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@celo/wallet-local/-/wallet-local-1.5.1.tgz#5f58a1f3bdce06392154459216647798e8e7d08a"
+  integrity sha512-StQU8R6SKo+T87LVxMxGG/8WRlruU5dze02Hs8vgEHt3LeYMsrX2k4+FkndANoJF9lhl+XvQrGD4gTaDC4b2ag==
   dependencies:
-    "@celo/connect" "1.3.3"
-    "@celo/utils" "1.3.3"
-    "@celo/wallet-base" "1.3.3"
+    "@celo/connect" "1.5.1"
+    "@celo/utils" "1.5.1"
+    "@celo/wallet-base" "1.5.1"
     "@types/ethereumjs-util" "^5.2.0"
     eth-lib "^0.2.8"
     ethereumjs-util "^5.2.0"
@@ -3045,6 +3045,15 @@ bip32@2.0.5:
     typeforce "^1.11.5"
     wif "^2.0.6"
 
+"bip39@git+https://github.com/bitcoinjs/bip39.git#d8ea080a18b40f301d4e2219a2991cd2417e83c2":
+  version "3.0.3"
+  resolved "git+https://github.com/bitcoinjs/bip39.git#d8ea080a18b40f301d4e2219a2991cd2417e83c2"
+  dependencies:
+    "@types/node" "11.11.6"
+    create-hash "^1.1.0"
+    pbkdf2 "^3.0.9"
+    randombytes "^2.0.1"
+
 "bip39@https://github.com/bitcoinjs/bip39#d8ea080a18b40f301d4e2219a2991cd2417e83c2":
   version "3.0.3"
   resolved "https://github.com/bitcoinjs/bip39#d8ea080a18b40f301d4e2219a2991cd2417e83c2"
@@ -3074,6 +3083,18 @@ block-stream@*:
   integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
   dependencies:
     inherits "~2.0.0"
+
+"bls12377js@git+https://github.com/celo-org/bls12377js.git#cb38a4cfb643c778619d79b20ca3e5283a2122a6":
+  version "0.1.0"
+  resolved "git+https://github.com/celo-org/bls12377js.git#cb38a4cfb643c778619d79b20ca3e5283a2122a6"
+  dependencies:
+    "@stablelib/blake2xs" "0.10.4"
+    "@types/node" "^12.11.7"
+    big-integer "^1.6.44"
+    chai "^4.2.0"
+    mocha "^6.2.2"
+    ts-node "^8.4.1"
+    typescript "^3.6.4"
 
 "bls12377js@https://github.com/celo-org/bls12377js#cb38a4cfb643c778619d79b20ca3e5283a2122a6":
   version "0.1.0"


### PR DESCRIPTION
Previously, we had CELO, cUSD and cEUR hard-coded to decide which token was user to pay for fees. This is now dynamic based on the tokens we have in Firebase.

We also had this problem for Exchanges, but I didn't fix it, I just hard-coded REAL as well (and updated contractkit to do so). It would be good to improve that and make it generic as well in the future.