### PR TITLE
chore(codecov): added coverage uploader to CI

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -24,6 +24,14 @@ jobs:
       - run: yarn
       - run: yarn build
       - run: yarn test
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v2
+        with:
+          path: coverage/lcov-report
+      - name: 'Upload coverage to Codecov'
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
   e2e:
     name: e2e
     runs-on: ubuntu-latest


### PR DESCRIPTION
I added an organization secret `CODECOV_TOKEN` for GH Actions, and a [global codecov config](https://app.codecov.io/account/gh/valora-inc/yaml), so this should be enough to enable codecov for this repo