### PR TITLE
docs: added build setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Install dependencies:
 yarn
 ```
 
+Build (must run first or tests will not pass!):
+```
+yarn build
+```
+
 ## Testing
 
 Unit tests, linting, and formatting:


### PR DESCRIPTION
I noticed that tests do not pass before running `yarn build`, so I added it to the README