### PR TITLE
Upgrade alfajores to Node 16

### DIFF
--- a/app.alfajores.yaml
+++ b/app.alfajores.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs12
+runtime: nodejs16
 service: blockchain-api
 env_variables:
   NODE_ENV: 'production'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "engines": {
-    "node": "^12"
+    "node": "*"
   },
   "author": "Valora Inc",
   "license": "Apache-2.0",


### PR DESCRIPTION
Temporarily drop node engines semver while we run on Node 16 in alfajores and
Node 12 in mainnet.