### PR TITLE
feat: add the ability to manually deploy from main

### DIFF
--- a/.github/workflows/alfajores-deploy.yaml
+++ b/.github/workflows/alfajores-deploy.yaml
@@ -1,12 +1,6 @@
-name: Workflow
+name: Alfajores Deploy
 
 on:
-  # Run on pushes to main..
-  push:
-    branches:
-      - main
-  # ..and any pull request.
-  pull_request:
   # Manually Run on Workflow Dispatch
   workflow_dispatch:
     inputs:
@@ -15,7 +9,7 @@ on:
         required: true
         default: 'warning'
       tags:
-        description: 'Mainnet and Alfajores manual deploy'
+        description: 'Aflajores manual deploy'
 
 concurrency:
   group: env-${{ github.ref }}
@@ -68,19 +62,3 @@ jobs:
           credentials_json: ${{ secrets.ALFAJORES_SERVICE_ACCOUNT_KEY }}
       - name: Deploy App
         run: ./deploy.sh -n alfajores
-  deploy-mainnet:
-    name: Deploy celo-mobile-mainnet
-    if: github.ref == 'refs/heads/main'
-    needs:
-      - e2e
-      - test
-      - deploy-alfajores
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: google-github-actions/auth@v0
-        with:
-          project_id: celo-mobile-mainnet
-          credentials_json: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}
-      - name: Deploy App
-        run: ./deploy.sh -n mainnet


### PR DESCRIPTION
### Description
Adds a manual dispatch to the workflow and another new workflow to manually dispatch main to Alfajores.
We could remove the check to allow branches to be deployed to Alfajores, but this could mess with CI as E2E tests for the wallet currently target Alfajores.

